### PR TITLE
Name appropiate device

### DIFF
--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -112,7 +112,7 @@ Details:
 
 No details (yet).
 
-###  ICPSHC24-10EU-IL-1 (10W LED driver/dimmer)
+### L1529 (FLOALT 60x60)
 
 Details:
 


### PR DESCRIPTION
The pictured devices in the source under ICPSHC24 is actually a FLOALT L1529. This can be seen on the background where it says L1529. The transformer is part of the FLOALT in this case. This also is apperant when looking at the actual outputs, they feed into 2 output stages.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>